### PR TITLE
Fix scutil parsing to support IPv6

### DIFF
--- a/osx/scutil.go
+++ b/osx/scutil.go
@@ -1,6 +1,7 @@
 package osx
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -66,7 +67,7 @@ func ParseScutilDns(data string) (*DnsInfo, error) {
 			if strings.HasPrefix(name, "search domain") {
 				currentResolver.SearchDomains = append(currentResolver.SearchDomains, value)
 			} else if strings.HasPrefix(name, "nameserver") {
-				currentResolver.Nameservers = append(currentResolver.Nameservers, value+":53")
+				currentResolver.Nameservers = append(currentResolver.Nameservers, fmt.Sprintf("[%s]:53", value))
 			} else if name == "reach" {
 				currentResolver.Reachable = !strings.Contains(value, "Not Reachable")
 			} else if name == "domain" {


### PR DESCRIPTION
IPv6 addresses are added in a manner that causes them to fail processing by `net.Dialer`:

```
ERRO[0004] error resolving query                         error="dial udp: address 2001:420:210d::a:53: too many colons in address" ns="2001:420:210d::a:53" qname=google.com.
ERRO[0005] error resolving query                         error="dial udp: address 2001:420:200:1::a:53: too many colons in address" ns="2001:420:200:1::a:53" qname=google.com.
```

This causes significant delays when IPv6 addresses are the first entries in the scutil output.

The correct behavior is to wrap the address in square brackets to differentiate address from port.  This can be done for IPv4 and IPv6 making the proposed patch the "cleanest" solution without having to further process the output from scutil.